### PR TITLE
ci(release): configure npm OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,11 +23,12 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v2
         with:
-          version: 10.12.3
+          version: 10.26.1
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -57,5 +58,4 @@ jobs:
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: pnpm release


### PR DESCRIPTION
- Add registry-url to setup-node for OIDC authentication
- Remove NPM_TOKEN dependency (using OIDC instead)
- Update pnpm version to 10.26.1
