### PR TITLE
fix(release): remove registry-url that interferes with npm OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '22'
-          registry-url: 'https://registry.npmjs.org'
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v2


### PR DESCRIPTION
The registry-url parameter in setup-node configures token-based auth, which conflicts with npm's native OIDC trusted publishing flow.
