### PR TITLE
fix(ci): add NPM_TOKEN to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,4 +57,5 @@ jobs:
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: pnpm release


### PR DESCRIPTION
OIDC provenance (package signing) requires id-token permission but npm publish authentication still requires NPM_TOKEN. The previous fix incorrectly assumed OIDC replaced authentication entirely.
