### PR TITLE
fix(ci): switch to pure OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,5 +57,4 @@ jobs:
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: pnpm release

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -31,8 +31,7 @@
       "@semantic-release/npm",
       {
         "pkgRoot": "packages/create-turbo-sanity",
-        "npmPublish": true,
-        "provenance": true
+        "npmPublish": true
       }
     ],
     [


### PR DESCRIPTION
## Summary
- Remove NPM_TOKEN authentication in favor of OIDC trusted publishing
- Remove explicit provenance flag (automatic with OIDC)
- Relies on trusted publisher already configured at npmjs.org

## Changes
- **`.github/workflows/release.yml`**: Removed NPM_TOKEN environment variable
- **`.releaserc.json`**: Removed explicit `provenance: true` flag (automatic with OIDC)

## Why
This eliminates long-lived tokens and follows npm's recommended approach for CI/CD authentication as of 2026. OIDC trusted publishing provides:
- No secrets to manage or rotate
- Automatic provenance attestations
- Better security with short-lived tokens
- Industry standard (OpenSSF)

## Test plan
- [x] Workflow has `id-token: write` permission
- [x] semantic-release bundles npm 11.8.0 (OIDC support)
- [x] Trusted publisher configured on npmjs.org
- [ ] Merge to main and verify release workflow succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)